### PR TITLE
(WIP) Makefile pro projeto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# Dependências
+# Apenas Node por enquanto...
+DEPS := docker npm node aglio
+CHECK := $(foreach dep, $(DEPS), \
+	$(if $(shell which $(dep)),\
+		"Checando $(dep)...",\
+		$(error "Dependência $(dep) não encontrado na $$PATH")\
+	))
+
+.PHONY: all
+
+all:
+	@echo "<TODO>"
+
+clean:
+	@echo "Removendo arquivos temporários"
+	@echo "<TODO>"
+
+tests:
+	@echo "<TODO>"
+
+# Node
+
+docs:
+	aglio -i ./app/docs/api-blueprint-sample.apib --theme-full-width --no-theme-condense -o ./app/templates/apidocs/index.html
+
+# Flask
+
+checa_virtualenv:
+	@if [ -z "$(VIRTUAL_ENV)" ]; then \
+		echo "ERROR: virtualenv não detectado." 1>&2;\
+		exit 1;\
+	fi
+
+pip: checa_virtualenv
+	@echo "<TODO>"
+
+# Docker
+
+compose:
+	docker-compose up -d --build
+


### PR DESCRIPTION
Adicionando um Makefile pro projeto. `Makefiles` são arquivos que interagem com o comando `make` e descrevem um conjunto de tarefas e a ordem que elas podem ser executadas. Um Makefile é composto de uma `target` (nome da regra), pré-requisitos (imports) e um conjunto de comandos (recipes).

```
# Alvo         Pré-requisitos
target ... : prerequisites ...
        # Instruções
        recipe 0
        recipe 1
        recipe 2
        ...
```

Para saber mais: [Como funciona o Makefile](https://blog.pantuza.com/tutoriais/como-funciona-o-makefile).

--------------

Alguns comandos implementados:

```
make docs - Gera a documentação com o aglio
make compose - Roda aquele comando do `docker-compose`
```

outros comandos ainda não implementados ou não terminados (ainda não peguei a manha pra rodar essas deps de Python no NixOS).

```
make pip - Checa se está num venv e instala as dependências do pip
make tests - Usa o pytest
make clean - Deleta arquivos temporários ou binários
make all - Roda todos os comandos
```


